### PR TITLE
Automatic Configuration Refresh

### DIFF
--- a/.dutirc
+++ b/.dutirc
@@ -1,0 +1,6 @@
+com.apple.automator.OpenInNvim c editor
+com.apple.automator.OpenInNvim c viewer
+com.apple.automator.OpenInNvim go editor
+com.apple.automator.OpenInNvim css editor
+com.apple.automator.OpenInNvim css viewer
+

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 2. Choose "New Document"
 3. Locate "Run AppleScript" and double-click it
 4. Paste the AppleScript code into the box
-5. Save as /Applications/OpenInNvim.app
+5. Save as `/Applications/OpenInNvim.app`
 6. In Finder, select some file you want to open in Vim, e.g. a .rb file.
-7. Hit ⌘I to open the “Get Info” window.
-8. Under “Open with:”, choose OpenInNvim.app. You may need to select “Other…” and then browse.
-9. Hit the “Change All…” button and confirm.
+7. Hit ⌘I to open the _“Get Info”_ window.
+8. Under _“Open with:”_, choose `OpenInNvim.app`. You may need to select _“Other…”_ and then browse.
+9. Hit the _“Change All…”_ button and confirm.
 
 ## Optional: Automatically Refresh Permissions
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-Open Automator
+# Installation
 
-Choose "New Document"
+1. Open Automator
+2. Choose "New Document"
+3. Locate "Run AppleScript" and double-click it
+4. Paste the AppleScript code into the box
+5. Save as /Applications/OpenInNvim.app
+6. In Finder, select some file you want to open in Vim, e.g. a .rb file.
+7. Hit ⌘I to open the “Get Info” window.
+8. Under “Open with:”, choose OpenInNvim.app. You may need to select “Other…” and then browse.
+9. Hit the “Change All…” button and confirm.
 
-Locate "Run AppleScript" and double-click it
+## Optional: Automatically Refresh Permissions
 
-Paste the Applescript code into the box
-
-Save as /Applications/TerminalVim.app
-
-In Finder, select some file you want to open in Vim, e.g. a .rb file.
-
-Hit ⌘I to open the “Get Info” window.
-
-Under “Open with:”, choose TerminalVim.app. You may need to select “Other…” and then browse.
-
-Hit the “Change All…” button and confirm.
+1. Edit `.dutirc` file adding relevant extensions to the list
+2. Copy `run_duti.sh` to the desired location.
+3. run `chmod +x run_duti.sh` to ensure that `run_duti.sh` is executable
+4. Edit path within the `com.user.dutirefresh.plist` to point to the `run_duti.sh` script. This will ensure permission refresh on startup.

--- a/com.user.dutirefresh.plist
+++ b/com.user.dutirefresh.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>Label</key>
+   <string>com.user.loginscript</string>
+   <key>ProgramArguments</key>
+   <array><string><!!Your path to run duti script!!>run_duti.sh</string></array>
+   <key>RunAtLoad</key>
+   <true/>
+</dict>
+</plist>

--- a/run_duti.sh
+++ b/run_duti.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+#
+# run_duti.sh
+# Copyright (C) 2024 Konrad <konrad.zdeb@me.com>
+#
+# Run Duti permission refresh script
+duti ~/.dutirc
+# Add console log on whether Duti refresh run successfully 
+if [ $? -eq 0 ]; then
+    syslog -s -k Facility com.apple.console \ 
+	    Level Info \ 
+	    Sender com.user.dutirefresh.plist \
+	    Message "Duti refresh run successfully."
+else
+    syslog -s -k Facility com.apple.console \ 
+	    Level Error \ 
+	    Sender com.user.dutirefresh.plist \
+	    Message "Duti refresh failed to run."
+fi
+
+


### PR DESCRIPTION
Good repo, I have used your script. I have added a set of steps to link your script-based app with [duti](https://github.com/moretension/duti) and [launchctl](https://ss64.com/mac/launchctl.html) so permissions can be continently maintained within a configuration file and automatically refreshed consistently with `launchctl` settings. I've edited `REAMDE.md` files and changed application name so the name clearly corresponds to the purpose.